### PR TITLE
Docker Compose script to run NCTL together with cors-anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ docker exec -it mynctl bash
 
 In the container shell you can use the `casper-client` tool as well as the `nctl-*` set of commands.
 
+## Use `cors-anywhere` to interact with the nodes from a browser
+
+Browsers block direct RPC calls to Casper nodes due to CORS. If you're developing a web app you may use `cors-anywhere` to overcome this situation. 
+
+The `cors` folder in this repository contains a Docker Compose configuration to start a node.js server running `cors-anywhere` in addition to the NCTL container. To start both containers run the following command:
+
+```bash
+cd cors
+docker compose up
+```
+
+Next, change your web app configuration to send the RPC calls to the node.js server indicating the casper node it has to redirect the traffic to:
+
+```
+http://127.0.0.1:11100/http://mynctl:11101/rpc
+```
+
+If you require a network with predefined accounts, starts the containers with this other compose file:
+
+```bash
+cd cors
+docker compose -f .\docker-compose-with-predefined-accounts.yml up
+```
 
 ## Use the Docker image in a GitHub action
 

--- a/cors/cors-anywhere.Dockerfile
+++ b/cors/cors-anywhere.Dockerfile
@@ -1,0 +1,10 @@
+FROM node:14-alpine
+
+ENV NODE_ENV=production
+ENV NODE_PATH=/usr/local/lib/node_modules
+ARG version=latest
+RUN npm install -g cors-anywhere@$version
+COPY server.js .
+CMD ["node", "server.js"]
+
+EXPOSE 11100

--- a/cors/docker-compose-with-predefined-accounts.yml
+++ b/cors/docker-compose-with-predefined-accounts.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+  mynctl:
+    image: makesoftware/casper-nctl
+    container_name: mynctl
+    ports:
+      - 11101-11105:11101-11105
+      - 14101-14105:14101-14105
+      - 18101-18105:18101-18105
+    command: ["/bin/bash", "-c", "source /home/casper/restart-with-predefined-accounts.sh"]
+  cors-anywhere:
+    container_name: cors-anywhere
+    build:
+      context: .
+      dockerfile: cors-anywhere.Dockerfile
+    tty: true
+    environment:
+      PORT: 11100
+    ports:
+      - 11100:11100

--- a/cors/docker-compose.yml
+++ b/cors/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+
+services:
+  mynctl:
+    image: makesoftware/casper-nctl
+    container_name: mynctl
+    ports:
+      - 11101-11105:11101-11105
+      - 14101-14105:14101-14105
+      - 18101-18105:18101-18105
+  cors-anywhere:
+    container_name: cors-anywhere
+    build:
+      context: .
+      dockerfile: cors-anywhere.Dockerfile
+    tty: true
+    environment:
+      PORT: 11100
+    ports:
+      - 11100:11100

--- a/cors/server.js
+++ b/cors/server.js
@@ -1,0 +1,13 @@
+// Listen on a specific host via the HOST environment variable
+var host = process.env.HOST || '0.0.0.0';
+// Listen on a specific port via the PORT environment variable
+var port = process.env.PORT || 11100;
+
+var cors_proxy = require('cors-anywhere');
+cors_proxy.createServer({
+    originWhitelist: [], // Allow all origins
+    requireHeader: ['origin', 'x-requested-with'],
+    removeHeaders: ['cookie', 'cookie2']
+}).listen(port, host, function() {
+    console.log('Running CORS Anywhere on ' + host + ':' + port);
+});


### PR DESCRIPTION
Added a Docker Compose script to build and run a container with `cors-anywhere`. This allows to make calls to the NCTL nodes from a browser.