### PR TITLE
Fix bash command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ nctl-view-user-secret-key user=3
 Each time the container is started, nctl runs with a set of randomly generated account keys. To use a set of predefined and pregenerated account keys, run the container with an extra parameter:
 
 ```bash
-docker run --rm -it --name mynctl -d -p 11101:11101 makesoftware/casper-nctl /bin/bash -c "/home/casper/restart-with-predefined-accounts.sh"
+docker run --rm -it --name mynctl -d -p 11101:11101 makesoftware/casper-nctl /bin/bash -c "source /home/casper/restart-with-predefined-accounts.sh"
 ```
 
 ### Stop the container


### PR DESCRIPTION
### Summary

command to start the container with predefined account requires 'source' param

Signed-off-by: David Hernando <david.hernando@make.services>

### TODO

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [] Tests included/updated or not needed
- [x] Documentation has been updated or is not required

