### PR TITLE
Fix for build image error

### DIFF
--- a/casper-nctl.Dockerfile
+++ b/casper-nctl.Dockerfile
@@ -32,7 +32,7 @@ RUN git clone https://github.com/casper-network/casper-node-launcher.git ~/caspe
     && source ~/casper-node/utils/nctl/sh/assets/compile.sh 
 
 # run clean-build-artifacts.sh to remove intermediate files and keep the image lighter
-COPY --chown=casper:casper ./clean-build-artifacts.sh .
+COPY ./clean-build-artifacts.sh .
 RUN chmod +x clean-build-artifacts.sh
 RUN ./clean-build-artifacts.sh
 


### PR DESCRIPTION
### Summary

Fixed build error. COPY command must not include user `casper` since …it's not created at that stage.

### TODO

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [x] Tests included/updated or not needed
- [x] Documentation has been updated or is not required

