### PR TITLE
add client branch option to docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# python env and test outputs
+env/*
+test/__pycache__/*

--- a/BUILD.md
+++ b/BUILD.md
@@ -5,18 +5,21 @@
 To build the NCTL docker image run `docker build` as follows:
 
 ```bash
-docker build -f casper-nctl.Dockerfile --build-arg GITBRANCH=release-1.4.15 -t casper-nctl:v1415 .
+docker build -f casper-nctl.Dockerfile --build-arg NODE_GITBRANCH=release-1.5.4 --build-arg CLIENT_GITBRANCH=release-2.0.0 -t casper-nctl:v154 .
 ```
 
-The argument `GITBRANCH` indicates which branch from the `casper-node` repository docker 
+The argument `NODE_GITBRANCH` indicates which branch from the `casper-node` repository docker 
 will download and build.
 
-In the command above, the image is tagged as v144, which is the latest `casper-node` version 
+The argument `CLIENT_GITBRANCH` indicates which branch from the `casper-client-rs` repository docker 
+will download and build.
+
+In the command above, the image is tagged as v154, which is the latest `casper-node` version 
 at the moment of writing these instructions. To keep other scripts independent of the version, 
 tag the image also as `latest` once the first build completes.
 
 ```bash
-docker tag casper-nctl:v1415 casper-nctl:latest
+docker tag casper-nctl:v154 casper-nctl:latest
 ```
 
 ## Test the docker image
@@ -31,7 +34,7 @@ pip install pytest testinfra
 Then, run `pytest` indicating the name of the docker image to test:
 
 ```
-pytest --image casper-nctl:v144
+pytest --image casper-nctl:v154
 ```
 
 ## Configure Docker Hub Automated Builds

--- a/casper-nctl.Dockerfile
+++ b/casper-nctl.Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:focal
 
-ARG GITBRANCH=release-1.4.15
+ARG NODE_GITBRANCH=release-1.4.15
+ARG CLIENT_GITBRANCH=main
 
 # DEBIAN_FRONTEND required for tzdata dependency install
 RUN apt-get update \
@@ -28,9 +29,9 @@ ENV NCTL_COMPILE_TARGET="release"
 # clone the casper-node repos and build binaries
 RUN git clone https://github.com/casper-network/casper-node-launcher.git ~/casper-node-launcher \
     && cd ~/casper-node-launcher && cargo build --release
-RUN git clone -b main https://github.com/casper-ecosystem/casper-client-rs ~/casper-client-rs \
+RUN git clone -b $CLIENT_GITBRANCH https://github.com/casper-ecosystem/casper-client-rs ~/casper-client-rs \
     && cd ~/casper-client-rs && cargo build --release
-RUN git clone -b $GITBRANCH https://github.com/casper-network/casper-node.git ~/casper-node \
+RUN git clone -b $NODE_GITBRANCH https://github.com/casper-network/casper-node.git ~/casper-node \
     && source ~/casper-node/utils/nctl/sh/assets/compile.sh 
 
 # run clean-build-artifacts.sh to remove intermediate files and keep the image lighter


### PR DESCRIPTION
* Resolves: #24 

### Summary

- Externalize client git branch as a build option
- Added `.gitignore` to not include any project scope env details and tests
- Updated `BUILD.md` with details about new option

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [x] Tests included/updated or not needed
- [x] Documentation has been updated or is not required

