### PR TITLE
Update the Discord url

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: ❓ Ask a question or discuss an idea
-    url: https://discord.gg/casperblockchain
+    url: https://discord.gg/caspernetwork
     about: Ask your questions and discuss your ideas in the `#smart-contracts` channel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ The following is a set of rules and guidelines for contributing to this repo. Pl
 ## Submitting issues
 
 If you have questions about how to use Casper NCTL - Docker Container, please direct these to the related discord channels:
-* [#smart-contracts](https://discord.gg/casperblockchain)
-* [#sdk-development](https://discord.gg/casperblockchain)
+* [#smart-contracts](https://discord.gg/caspernetwork)
+* [#sdk-development](https://discord.gg/caspernetwork)
 
 ### Guidelines
 * Please search the existing issues first, it's likely that your issue was already reported or even fixed.


### PR DESCRIPTION
The new/current official Discord url is https://discord.gg/caspernetwork